### PR TITLE
Creating connections simpler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ function getRandomColor() {
 //create the pattern for the board
 var segmentOne = {startX: 10, startY:10, length: 5, orientation: "horizontal"}
 var segmentTwo = {startX: 10, startY:10, length: 5, orientation: "vertical"}
-var options = {segments: [segmentOne, segmentTwo] }
+var options = {segments: [segmentOne, segmentTwo], connections: [{x: 10, y: 10}]}
 var pattern = new Pattern(options)
 var arrays = []
 pattern.segments.forEach(function(segment){
@@ -26,12 +26,7 @@ pattern.segments.forEach(function(segment){
 })
 
 var blocks = [].concat.apply([], arrays);
-console.log(blocks)
-// var segment = new Segment();
-// segment.create({startX:0, startY:10, length: 40, orientation: "horizontal"})
-// var blocks = segment.allBlocks();
 
-var board = {minX: 0, maxX: 400, minY: 10, maxY: 20};
 var compColor = "blue";
 var compBlock;
 
@@ -50,9 +45,6 @@ var userColor = "red";
 canvas.addEventListener('click', function (event) {
   console.log(helper(event));
   var click = helper(event);
-  var clickWithinX = click.x >= board.minX && click.x <= board.maxX
-  var clickWithinY = click.y >= board.minY && click.y <= board.maxY
-  if (clickWithinX && clickWithinY){
     blocks.forEach(function(block){
       if (block.contains({x: click.x, y: click.y})){
         console.log("You got a block!", block.x, block.y, block.color)
@@ -61,35 +53,62 @@ canvas.addEventListener('click', function (event) {
         }else{
           block.color = userColor;
           block.draw(block.color, context);
-          expandColor(compBlock);
-          expandColor(block);
-          getColorPercents();
+          fillIn(compBlock, block)
         }
       }
     })
-  }
 });
+
+function fillIn(comp, user){
+  expandColor(comp);
+  expandColor(user);
+}
 
 function expandColor(currentBlock){
   var parent = currentBlock.parent
   var child = currentBlock.child
   var currentGreyParent = parent && parent.color === "grey"
   var currentGreyChild = child && child.color === "grey"
+  if(isCurrentConnection(currentBlock)){
+    var eachBlock = eachConnectionBlock(currentBlock)
+    eachBlock.forEach(function(block){
+      if(block.color === "grey"){
+        block.color = currentBlock.color;
+        block.draw(block.color, context)
+        expandColor(block);
+      }
+    })
+  }
   if (currentGreyParent){
     parent.color = currentBlock.color;
     parent.draw(parent.color, context);
-    expandColor(parent)
+    setTimeout(expandColor, 70, parent)
   }
   if (currentGreyChild){
     child.color = currentBlock.color;
     child.draw(child.color, context);
-    expandColor(child)
+    setTimeout(expandColor, 70, child)
   }
 }
 
-function getColorPercents(){
-  var compColorAmount = segment.colorAmount(compColor)
-  var playerColorAmount = segment.colorAmount(userColor)
-  console.log("Computer %: ", compColorAmount/segment.length)
-  console.log("Player %: ", playerColorAmount/segment.length)
+function eachConnectionBlock(currentBlock){
+  var blocks = []
+  pattern.segments.forEach(function(segment){
+    blocks.push(segment.find(currentBlock))
+  });
+  blocks = [].concat.apply([], blocks);
+  return blocks
+}
+
+function isCurrentConnection(currentBlock){
+  var result;
+  var connections = pattern.connections
+  connections.forEach(function(connection){
+    if (currentBlock.x == connection.x && currentBlock.y == connection.y){
+      result = true
+    }else{
+      result = false
+    }
+  })
+  return result
 }

--- a/lib/pattern.js
+++ b/lib/pattern.js
@@ -4,6 +4,7 @@ const Segment = require('../lib/segment.js');
 function Pattern(options = {}){
   this.segmentDatas = options.segments || 0;
   this.segments = this.build();
+  this.connections = options.connections || [];
 }
 
 Pattern.prototype.build = function(){

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -57,5 +57,12 @@ Segment.prototype.colorAmount = function (color) {
   return count
 };
 
+Segment.prototype.find = function (currentBlock) {
+  var result = this.allBlocks().filter(function(block){
+    return currentBlock.x == block.x && currentBlock.y == block.y
+  })
+  return result
+};
+
 
 module.exports = Segment;

--- a/test/pattern_test.js
+++ b/test/pattern_test.js
@@ -21,13 +21,15 @@ describe("Pattern", function(){
     it("and builds the segments", function(){
       var segmentOne = {startX: 10, startY:10, length: 5, orientation: "horizontal"}
       var segmentTwo = {startX: 10, startY:10, length: 5, orientation: "vertical"}
-      var options = {segments: [segmentOne, segmentTwo] }
+      var connections = [{x: 10, y: 10}]
+      var options = {segments: [segmentOne, segmentTwo], connections: connections }
       var pattern = new Pattern(options)
       assert.deepEqual(pattern.segmentDatas, [segmentOne, segmentTwo])
       pattern.build()
       assert.deepEqual(pattern.segments.length, 2)
       var segOne = pattern.segments[0]
       assert(segOne.head instanceof Block)
+      assert.deepEqual(pattern.connections, [{x: 10, y: 10}])
     })
 
   })


### PR DESCRIPTION
Problem: segments rendered without knowledge of each other; blocks where they overlapped were being drawn twice so that the color was not expanding into a connecting segment.

Solution: added logic in the expandColor function to check if the current block was a connection. If so, change its color so that it triggers fill of its parent and child blocks. 
