### PR TITLE
50 fix color fill logic

### DIFF
--- a/lib/color_filler.js
+++ b/lib/color_filler.js
@@ -1,3 +1,5 @@
+var colors = require('./colors')
+
 function ColorFiller(currentBlock, pattern) {
   this.pattern = pattern;
   this.currentBlock = currentBlock;
@@ -20,8 +22,8 @@ ColorFiller.prototype.expandColor = function(currentBlock, context, compColor, u
   calculateColorValues(game, userColor);
   var parent = currentBlock.parent;
   var child = currentBlock.child;
-  var currentGreyParent = parent && parent.color === "grey";
-  var currentGreyChild = child && child.color === "grey";
+  var currentGreyParent = parent && parent.color === colors.board;
+  var currentGreyChild = child && child.color === colors.board;
 
   if (isCurrentConnection(currentBlock, this.pattern, context)){
     this.fillDoubleBlock(currentBlock, context, this.pattern, compColor, userColor, game);

--- a/lib/color_filler.js
+++ b/lib/color_filler.js
@@ -1,4 +1,4 @@
-var colors = require('./colors')
+var colors = require('./colors');
 
 function ColorFiller(currentBlock, pattern) {
   this.pattern = pattern;
@@ -45,15 +45,13 @@ function fillInNeighborBlock(neighbor, currentBlock, context, compColor, userCol
 
 ColorFiller.prototype.fillDoubleBlock = function(currentBlock, context, pattern, compColor, userColor, game){
   var eachBlock = eachConnectionBlock(currentBlock, pattern);
-  eachBlock.forEach(function(block){
-    if (block.color === "grey") {
-      colorDoubleBlockCorrectly.call(this, block, currentBlock, context, compColor, userColor, game);
-    } else if (currentBlock.color === "blue" && block.color === "red") {
-      colorDoubleBlockCorrectly.call(this, block, currentBlock, context, compColor, userColor, game);
-    } else if (currentBlock.color === "red" && block.color === "blue") {
-      colorDoubleBlockCorrectly.call(this, block, currentBlock, context, compColor, userColor, game);
-    }
-  }.bind(this));
+  if (eachBlock[0].color !== eachBlock[1].color) {
+    var copyBlockArray = eachBlock.filter(function(block){
+      return currentBlock.color !== block.color;
+    });
+    var copyBlock = copyBlockArray[0];
+    colorDoubleBlockCorrectly.call(this, copyBlock, currentBlock, context, compColor, userColor, game);
+  }
 };
 
 function colorDoubleBlockCorrectly(doubleBlock, currentBlock, context, compColor, userColor, game){

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -1,0 +1,12 @@
+var pink   = "#FF0066";
+var blue   = "#2BFDC9";
+var orange = "#FDB12B";
+
+var colors = {
+  user: orange,
+  board: "grey",
+  compOne: pink,
+  compTwo: blue
+};
+
+module.exports = colors;


### PR DESCRIPTION
Closes #50 
This PR creates a color object to store colors instead of hard coding them
- It should be changed in the other files that use colors; currently only changed in the color filler class

It aslo fixes the fillDoubleBlock method in the color filler to fix bug of colors filling past each other in same cases
- Problem was that the method had many if/ else checks for different cases of the colors of the connection blocks, but then was executing the same method in each case
- the logic was clarified so that when the current block is a connection, we check these things:
- Are the connection blocks (an array of two blocks) the same color?
- If they are not, then change the copy block to the color of the current block and keep filling recursively.
- If they are the same color, it means the logic above has already been executed, so we don't need to do it again. 

Note: currently the check for if the connection blocks have the same color is hard coded using index 0 and 1 in the eachBlock array, but in the future this could be changed to be more readable, because as it is it assumes the dev knows that the array is an array of only two blocks. 
